### PR TITLE
features: Connect.feature: Update default config in firmware test

### DIFF
--- a/features/Connect.feature
+++ b/features/Connect.feature
@@ -3,7 +3,7 @@ Feature: Connect
     The Cat Tracker should connect to the AWS IoT broker
 
     Background:
-        
+
         Given I am run after the "Run the firmware" feature
         Given I am authenticated with AWS key "{awsAccessKeyId}" and secret "{awsSecretAccessKey}"
 
@@ -29,10 +29,10 @@ Feature: Connect
             "cfg": {
                 "gpst": 60,
                 "act": true,
-                "actwt": 60,
-                "mvres": 60,
+                "actwt": 120,
+                "mvres": 120,
                 "mvt": 3600,
-                "acct": 100
+                "acct": 10
             }
         }
         """


### PR DESCRIPTION
The default configuration for the application has changes. Update the
test with the new config values.

The firmware test checks that the device reports its default
configuration after an established connection. If there is a mismatch
between the expected default values and the reported default values
the firmware test fails.

Active wait timeout (actwt) and movement resolution (mvres) are now set
to 120. This is to avoid the possibility of GPS data getting requested
during a GPS search because the timeouts are too close to the
GPS timeout. It doesnt hurt to give the application some wiggle-room.

The accelerometer threshold (acct) is now set to 10 m/s2 instead of 100.
100 m/s2 is simply an unrealistic threshold and exceeds the
measuring range of the ADXL362, present on the Thingy91.