### PR TITLE
feat: enable SUPL client

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,6 +49,8 @@ jobs:
   docker:
     name: Prepare Docker image
     runs-on: ubuntu-latest
+    env:
+      SUPL_CLIENT_LIB_DOWNLOAD: ${{ secrets.SUPL_CLIENT_LIB_DOWNLOAD }}
     steps:
       - uses: actions/checkout@v2
 
@@ -102,6 +104,9 @@ jobs:
         network: [nbiot, ltem]
         loglevel: [debug, nodebug]
 
+    env:
+      SUPL_CLIENT_LIB_DOWNLOAD: ${{ secrets.SUPL_CLIENT_LIB_DOWNLOAD }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -128,6 +133,13 @@ jobs:
         run: |
           BROKER_HOSTNAME=`cat broker.conf`
           echo "CONFIG_AWS_IOT_BROKER_HOST_NAME=\"${BROKER_HOSTNAME}\"" >> prj.conf
+
+      - name: Enable SUPL client
+        if: env.SUPL_CLIENT_LIB_DOWNLOAD != ''
+        run: |
+          echo "CONFIG_SUPL_CLIENT_LIB=y" >> prj.conf
+          echo "CONFIG_AGPS=y" >> prj.conf
+          echo "CONFIG_AGPS_SRC_SUPL=y" >> prj.conf
 
       - run: cat prj.conf
 

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -62,7 +62,9 @@ jobs:
 
       - name: Determine checksum for Docker image
         run: |
-          DOCKER_CHECKSUM=`cat Dockerfile west.yml | sha256sum | awk '{ print $1 }' | tr -d '\n'`
+          echo $SUPL_CLIENT_LIB_DOWNLOAD > .docker-checksum
+          cat Dockerfile west.yml >> .docker-checksum
+          DOCKER_CHECKSUM=`sha256sum .docker-checksum | awk '{ print $1 }' | tr -d '\n'`
           echo "DOCKER_CHECKSUM=${DOCKER_CHECKSUM}" >> $GITHUB_ENV
 
       - name: Sign in to the GitHub Container Registry
@@ -79,7 +81,9 @@ jobs:
 
       - name: Build Docker image
         if: steps.check-docker-image.outcome == 'failure'
-        run: docker build -t asset-tracker-firmware-docker .
+        run:
+          docker build --build-arg SUPL_CLIENT_LIB_DOWNLOAD -t
+          asset-tracker-firmware-docker .
 
       - name: Tag Docker image
         if: steps.check-docker-image.outcome == 'failure'
@@ -145,7 +149,9 @@ jobs:
 
       - name: Determine checksum for Docker image
         run: |
-          DOCKER_CHECKSUM=`cat Dockerfile west.yml | sha256sum | awk '{ print $1 }' | tr -d '\n'`
+          echo $SUPL_CLIENT_LIB_DOWNLOAD > .docker-checksum
+          cat Dockerfile west.yml >> .docker-checksum
+          DOCKER_CHECKSUM=`sha256sum .docker-checksum | awk '{ print $1 }' | tr -d '\n'`
           echo "DOCKER_CHECKSUM=${DOCKER_CHECKSUM}" >> $GITHUB_ENV
 
       - name: Determine GitHub Container Registry repo name
@@ -198,6 +204,7 @@ jobs:
       DEVICE_ID: ${{ secrets.DEVICE_ID }}
       CI: 1
       FORCE_COLOR: 3
+      SUPL_CLIENT_LIB_DOWNLOAD: ${{ secrets.SUPL_CLIENT_LIB_DOWNLOAD }}
 
     steps:
       - uses: actions/checkout@v2
@@ -266,7 +273,9 @@ jobs:
 
       - name: Determine checksum for Docker image
         run: |
-          DOCKER_CHECKSUM=`cat Dockerfile west.yml | sha256sum | awk '{ print $1 }' | tr -d '\n'`
+          echo $SUPL_CLIENT_LIB_DOWNLOAD > .docker-checksum
+          cat Dockerfile west.yml >> .docker-checksum
+          DOCKER_CHECKSUM=`sha256sum .docker-checksum | awk '{ print $1 }' | tr -d '\n'`
           echo "DOCKER_CHECKSUM=${DOCKER_CHECKSUM}" >> $GITHUB_ENV
 
       - name: Sign in to the GitHub Container Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN test -z "$SUPL_CLIENT_LIB_DOWNLOAD" || \
         apt-get -y install unzip && \
         wget -q $SUPL_CLIENT_LIB_DOWNLOAD -O supl_client.zip && \
         unzip supl_client.zip && \
-        mv -v supl /workdir/ncs/nrf/ext/lib/bin/supl \
+        mkdir -p /workdir/ncs/nrf/ext/lib/bin && \
+        mv -v supl /workdir/ncs/nrf/ext/lib/bin \
     " && :

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,12 @@ RUN \
     pip3 install -r nrf/scripts/requirements.txt && \
     pip3 install -r bootloader/mcuboot/scripts/requirements.txt && \
     rm -rf /workdir/ncs/firmware
+# Optionally fetch the SUPL client
+ARG SUPL_CLIENT_LIB_DOWNLOAD
+RUN test -z "$SUPL_CLIENT_LIB_DOWNLOAD" || \
+    /bin/bash -c "\
+        apt-get -y install unzip && \
+        wget -q $SUPL_CLIENT_LIB_DOWNLOAD -O supl_client.zip && \
+        unzip supl_client.zip && \
+        mv -v supl /workdir/ncs/nrf/ext/lib/bin/supl \
+    " && :

--- a/README.md
+++ b/README.md
@@ -14,5 +14,13 @@ implementation of the Asset Tracker Example.
 The copy is regularly updated from source and kept in sync with the NCS release
 branches.
 
+## SUPL Client
+
+If the GitHub Action secret `SUPL_CLIENT_LIB_DOWNLOAD` is configured and
+pointing to a HTTP link with the
+[SUPL Client library](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/supl_os_client.html#downloading-and-installing)
+(e.g. `https://example.com/nrf9160_libsupl-v0.7.0-809cb2e.zip`), the SUPL client
+will be compiled and AGPS enabled.
+
 > :information_source:
 > [Read the complete Asset Tracker Cloud Example documentation](https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/).

--- a/west.yml
+++ b/west.yml
@@ -1,4 +1,5 @@
 manifest:
+  version: 0.9
   remotes:
     - name: nordic
       url-base: https://github.com/nrfconnect


### PR DESCRIPTION
This optionally enables the SUPL client in the build.

Set the `SUPL_CLIENT_LIB_DOWNLOAD` secret to a URL in order to enable it