### PR TITLE
fix: disable debug logging when building with Memfault

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         board: [thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns]
-        loglevel: [debug, debugWithMemfault, nodebug]
+        loglevel: [debug, nodebug, nodebugMemfault]
 
     steps:
       - uses: actions/checkout@v3
@@ -131,8 +131,8 @@ jobs:
         run: |
           docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b ${{ matrix.board }} -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf" -DEXTRA_CFLAGS="-Werror=format-truncation"'
 
-      - name: Build with debug and Memfault enabled
-        if: matrix.loglevel == 'debugWithMemfault'
+      - name: Build with Memfault enabled
+        if: matrix.loglevel == 'nodebugMemfault'
         run: |
           echo "CONFIG_NRF_MODEM_LIB_TRACE_ENABLED=y" >> firmware/firmware.conf
           echo "CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT=y" >> firmware/firmware.conf
@@ -141,10 +141,10 @@ jobs:
           echo "CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.APP_VERSION }}\"" >> firmware/firmware.conf
           echo "CONFIG_MEMFAULT_NCS_FW_TYPE=\"asset_tracker_v2\"" >> firmware/firmware.conf
           echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> firmware/firmware.conf
-          docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b ${{ matrix.board }} -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf" -DEXTRA_CFLAGS="-Werror=format-truncation"'
+          docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b ${{ matrix.board }} -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-memfault.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf" -DEXTRA_CFLAGS="-Werror=format-truncation"'
 
       - name: Upload symbols file to Memfault
-        if: matrix.loglevel == 'debugWithMemfault'
+        if: matrix.loglevel == 'nodebugMemfault'
         run: |
           pip3 install memfault-cli
           memfault \

--- a/package.json
+++ b/package.json
@@ -127,44 +127,44 @@
               "label": "Symbol file for nRF9160 DK (debug) firmware"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-debugWithMemfault-*/merged.hex",
-              "name": "asset_tracker_v2-Thingy91-debugWithMemfault-${nextRelease.gitTag}.hex",
-              "label": "Pre-build HEX file for Thingy:91 (debug with Memfault)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-nodebugMemfault-*/merged.hex",
+              "name": "asset_tracker_v2-Thingy91-nodebugMemfault-${nextRelease.gitTag}.hex",
+              "label": "Pre-build HEX file for Thingy:91 (Memfault)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-debugWithMemfault-*/app_signed.hex",
-              "name": "asset_tracker_v2-Thingy91-debugWithMemfault-${nextRelease.gitTag}-signed.hex",
-              "label": "Pre-build HEX file for Thingy:91 (debug with Memfault, signed)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-nodebugMemfault-*/app_signed.hex",
+              "name": "asset_tracker_v2-Thingy91-nodebugMemfault-${nextRelease.gitTag}-signed.hex",
+              "label": "Pre-build HEX file for Thingy:91 (Memfault, signed)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-debugWithMemfault-*/app_update.bin",
-              "name": "asset_tracker_v2-Thingy91-debugWithMemfault-app_upgrade-${nextRelease.gitTag}.bin",
-              "label": "App upgrade file for Thingy:91 (debug with Memfault)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-nodebugMemfault-*/app_update.bin",
+              "name": "asset_tracker_v2-Thingy91-nodebugMemfault-app_upgrade-${nextRelease.gitTag}.bin",
+              "label": "App upgrade file for Thingy:91 (Memfault)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-debugWithMemfault-*/zephyr.elf",
-              "name": "asset_tracker_v2-Thingy91-debugWithMemfault-app_upgrade-${nextRelease.gitTag}.elf",
-              "label": "Symbol file for Thingy:91 (debug with Memfault) firmware"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/thingy91_nrf9160_ns-nodebugMemfault-*/zephyr.elf",
+              "name": "asset_tracker_v2-Thingy91-nodebugMemfault-app_upgrade-${nextRelease.gitTag}.elf",
+              "label": "Symbol file for Thingy:91 (Memfault) firmware"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-debugWithMemfault-*/merged.hex",
-              "name": "asset_tracker_v2-nRF9160DK-debugWithMemfault-${nextRelease.gitTag}.hex",
-              "label": "Pre-build HEX file for nRF9160 DK (debug with Memfault)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-nodebugMemfault-*/merged.hex",
+              "name": "asset_tracker_v2-nRF9160DK-nodebugMemfault-${nextRelease.gitTag}.hex",
+              "label": "Pre-build HEX file for nRF9160 DK (Memfault)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-debugWithMemfault-*/app_signed.hex",
-              "name": "asset_tracker_v2-nRF9160DK-debugWithMemfault-${nextRelease.gitTag}-signed.hex",
-              "label": "Pre-build HEX file for nRF9160 DK (debug with Memfault, signed)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-nodebugMemfault-*/app_signed.hex",
+              "name": "asset_tracker_v2-nRF9160DK-nodebugMemfault-${nextRelease.gitTag}-signed.hex",
+              "label": "Pre-build HEX file for nRF9160 DK (Memfault, signed)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-debugWithMemfault-*/app_update.bin",
-              "name": "asset_tracker_v2-nRF9160DK-debugWithMemfault-app_upgrade-${nextRelease.gitTag}.bin",
-              "label": "App upgrade file for nRF9160 DK (debug with Memfault)"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-nodebugMemfault-*/app_update.bin",
+              "name": "asset_tracker_v2-nRF9160DK-nodebugMemfault-app_upgrade-${nextRelease.gitTag}.bin",
+              "label": "App upgrade file for nRF9160 DK (Memfault)"
             },
             {
-              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-debugWithMemfault-*/zephyr.elf",
-              "name": "asset_tracker_v2-nRF9160DK-debugWithMemfault-app_upgrade-${nextRelease.gitTag}.elf",
-              "label": "Symbol file for nRF9160 DK (debug with Memfault) firmware"
+              "path": "/home/runner/work/asset-tracker-cloud-firmware-aws/asset-tracker-cloud-firmware-aws/nrf9160dk_nrf9160_ns-nodebugMemfault-*/zephyr.elf",
+              "name": "asset_tracker_v2-nRF9160DK-nodebugMemfault-app_upgrade-${nextRelease.gitTag}.elf",
+              "label": "Symbol file for nRF9160 DK (Memfault) firmware"
             }
           ]
         }


### PR DESCRIPTION
The recent changes in libc cause the image to use too
much memory. Until fixed, this should solve the issue.
